### PR TITLE
Add simple setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='aws-glue-libs',
+    version='0.0.1',
+    long_description=__doc__,
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
This would make these libs a bit more usable as an installable dependency. For example, with this setup.py, I can now install these libs via pip:
```
$ pip install -e git://github.com/acmcelwee/aws-glue-libs#egg=aws-glue-libs
Obtaining aws-glue-libs from git+git://github.com/acmcelwee/aws-glue-libs#egg=aws-glue-libs
  Cloning git://github.com/acmcelwee/aws-glue-libs to /Users/adam/.virtualenvs/yellowbird/src/aws-glue-libs
Installing collected packages: aws-glue-libs
  Running setup.py develop for aws-glue-libs
Successfully installed aws-glue-libs
```
