### PR TITLE
Enable spark interactive shell with glue 

### DIFF
--- a/bin/gluespark-shell
+++ b/bin/gluespark-shell
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(cd $(dirname "$0")/..; pwd)"
+source $ROOT_DIR/bin/glue-setup.sh
+exec "${SPARK_HOME}/bin/spark-shell" "$@"


### PR DESCRIPTION
*Enable spark interactive shell with glue *


*Added the file to trigger the spark-shell for scala developers with glue library support*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
