### PR TITLE
Add setup.py for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='aws-glue-libs',
+    version='3.0.0',
+    long_description=__doc__,
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
Allows the repository to be installed via pip:
`pip install -e git://github.com/stevenayers/aws-glue-libs#egg=aws-glue-libs`