### PR TITLE
Add setup.py file to glue-1.0 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='aws-glue-libs',
+    version='1.0.0',
+    long_description=__doc__,
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Adds `setup.py` file to `glue-1.0` branch.


Context:

I am using [PDM](https://github.com/pdm-project/pdm) to manage dependencies for an internal Python library that runs in AWS as a Glue 1.0 job (with Python 2.7), and am trying to install the `awsglue` package from this repository for local testing. I cannot install [the `awsglue-local` library](https://pypi.org/project/awsglue-local/) as that requires Python 3. PDM can install packages from git but they need to have a `pyproject.toml` file or a `setup.py` file - see this comment from the author: https://github.com/pdm-project/pdm/issues/1036#issuecomment-1097460895

The `master` branch of this repository contains a `setup.py` file, so I'm hoping it's acceptable to add one to the `glue-1.0` branch as well. I am able to successfully install this package via PDM when the setup.py file is present.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
