### PR TITLE
Add license to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,5 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
+    license='Amazon Software License 1.0',
 )


### PR DESCRIPTION
*Issue #, if available:* #155

*Description of changes:*  This addition is meant to resolve #155.  Whenever SBOM or other license compliance tools are executed against a project that is consuming this module as a dependency, the license is returned as `Unknown` because we aren't defining the license as a part of the actual package meta.  This resolves the absent meta issue by adding the license: `Amazon Software License 1.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
