### PR TITLE
feat: add support for coverage

### DIFF
--- a/bin/gluecoverage
+++ b/bin/gluecoverage
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(cd $(dirname "$0")/..; pwd)"
+source $ROOT_DIR/bin/glue-setup.sh
+exec coverage "$@"


### PR DESCRIPTION
Add a script for measuring coverage of tests executed via pytest (gluepytest) (cf. https://coverage.readthedocs.io/)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
