### PR TITLE
Add Validation for Python Script Argument in gluepyspark Script

### DIFF
--- a/bin/gluepyspark
+++ b/bin/gluepyspark
@@ -2,4 +2,12 @@
 
 ROOT_DIR="$(cd $(dirname "$0")/..; pwd)"
 source $ROOT_DIR/bin/glue-setup.sh
+
+for arg in "$@"; do
+  if [[ $arg == *.py ]]; then
+	echo "Use ./bin/gluesparksubmit <Python script path> if you want to run a script through glue. This script, i.e., gluepyspark, is used to launch an interactive session."
+	exit 1
+  fi
+done
+
 exec "${SPARK_HOME}/bin/pyspark" "$@"


### PR DESCRIPTION
The gluepyspark script should validate whether any of the provided arguments are Python scripts (i.e., files with a .py extension). If a Python script is detected, the script should display the following message and exit:
`Please use ./bin/gluesparksubmit <Python script path> to run scripts through Glue.`

This change ensures that gluepyspark is used exclusively for launching interactive sessions.

Proposed Change: Add a loop to iterate through the provided arguments and check if any argument ends with .py. If such an argument is found, print a message and exit the script.

Impact: This change will prevent users from mistakenly using gluepyspark to run Python scripts, ensuring that the script is used only for its intended purpose of launching interactive sessions.