### PR TITLE
Fix Python 3 compatibility: Add missing basestring shim to utils.py

### DIFF
--- a/awsglue/utils.py
+++ b/awsglue/utils.py
@@ -51,6 +51,7 @@ def callsite():
 
 # Definitions for Python 2/Python 3
 if sys.version >= "3":
+    basestring = unicode = str
     def iteritems(d, **kwargs):
         return iter(d.items(**kwargs))
     def iterkeys(d, **kwargs):


### PR DESCRIPTION
**Description of changes:**
Added `basestring = unicode = str` to the existing Python 2/3 compatibility section in `utils.py` to match the pattern already implemented in `gluetypes.py` and `dynamicframe.py`.

*Problem:*
- The `makeOptions` function uses `isinstance(py_obj, basestring)` 
- `basestring` was removed in Python 3, causing crashes
- Other AWS Glue files already have this compatibility shim, but `utils.py` was missing it

*Solution:*
- Added one line: `basestring = unicode = str` to the existing `if sys.version >= "3":` block
- This makes the code consistent with the approach used in other files
- No functional changes to the logic, just Python 3 compatibility


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
