### PR TITLE
Glue 5.0 changes

### DIFF
--- a/awsglue/context.py
+++ b/awsglue/context.py
@@ -12,8 +12,7 @@
 
 from pyspark.sql import SQLContext
 from pyspark.sql import SparkSession
-from py4j.java_gateway import java_import
-from pyspark.sql.utils import StreamingQueryException
+from py4j.java_gateway import java_import # type: ignore
 
 from awsglue.data_source import DataSource
 from awsglue.streaming_data_source import StreamingDataSource
@@ -53,15 +52,23 @@ class GlueContext(SQLContext):
     Spark_SQL_Formats = {"parquet", "orc"}
     Unsupported_Compression_Types = {"lzo"}
 
-    def __init__(self, sparkContext, **options):
-        super(GlueContext, self).__init__(sparkContext)
+    def __init__(self, sparkContext=None, **options):
+        if not sparkContext:
+            spark_session = SparkSession.builder.getOrCreate()
+            sparkContext = spark_session.sparkContext
+        elif type(sparkContext) == SparkSession:
+            spark_session = sparkContext
+            sparkContext = spark_session.sparkContext
+        else:
+            spark_session = SparkSession.builder.getOrCreate()
+        super(GlueContext, self).__init__(sparkContext, spark_session)
         register(sparkContext)
         self._glue_scala_context = self._get_glue_scala_context(**options)
         self.create_dynamic_frame = DynamicFrameReader(self)
         self.create_data_frame = DataFrameReader(self)
         self.write_dynamic_frame = DynamicFrameWriter(self)
         self.write_data_frame = DataFrameWriter(self)
-        self.spark_session = SparkSession(sparkContext, self._glue_scala_context.getSparkSession())
+        self.spark_session = self.sparkSession
         self._glue_logger = sparkContext._jvm.GlueLogger()
 
     @property

--- a/awsglue/data_source.py
+++ b/awsglue/data_source.py
@@ -12,6 +12,7 @@
 
 from awsglue.dynamicframe import DynamicFrame
 from awsglue.utils import makeOptions, callsite
+from pyspark.sql import DataFrame
 
 class DataSource(object):
     def __init__(self, j_source, sql_ctx, name):
@@ -42,3 +43,7 @@ class DataSource(object):
     def getSampleFrame(self, num, **options):
         jframe = self._jsource.getSampleDynamicFrame(num, makeOptions(self._sql_ctx._sc, options))
         return DynamicFrame(jframe, self._sql_ctx, self.name)
+
+    def getDataFrame(self):
+        jdf = self._jsource.getDataFrame()
+        return DataFrame(jdf, self._sql_ctx)

--- a/awsglue/dataframe_transforms/apply_mapping.py
+++ b/awsglue/dataframe_transforms/apply_mapping.py
@@ -10,7 +10,7 @@
 # or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from py4j.java_gateway import java_import
+from py4j.java_gateway import java_import # type: ignore
 from pyspark.sql.dataframe import DataFrame
 
 class ApplyMapping():

--- a/awsglue/dataframereader.py
+++ b/awsglue/dataframereader.py
@@ -9,7 +9,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
 # or implied. See the License for the specific language governing
 # permissions and limitations under the License.
- 
+
 class DataFrameReader(object):
     def __init__(self, glue_context):
         self._glue_context = glue_context

--- a/awsglue/dynamicframe.py
+++ b/awsglue/dynamicframe.py
@@ -20,13 +20,10 @@ from pyspark.rdd import RDD, PipelinedRDD
 from pyspark.sql.dataframe import DataFrame
 from pyspark.serializers import PickleSerializer, BatchedSerializer
 
-if sys.version >= "3":
-    long = int
-    basestring = unicode = str
-    imap=map
-    ifilter=filter
-else:
-    from itertools import imap, ifilter
+long = int
+basestring = unicode = str
+imap = map
+ifilter = filter
 
 class ResolveOption(object):
     """
@@ -147,7 +144,7 @@ class DynamicFrame(object):
         return DataFrame(self._jdf.toDF(self.glue_ctx._jvm.PythonUtils.toSeq(scala_options)), self.glue_ctx)
 
     @classmethod
-    def fromDF(cls, dataframe, glue_ctx, name):
+    def fromDF(cls, dataframe, glue_ctx, name=""):
         """
         Convert a DataFrame to a DynamicFrame by converting DynamicRecords to Rows
         :param dataframe: A spark sql DataFrame
@@ -157,7 +154,6 @@ class DynamicFrame(object):
         """
         return DynamicFrame(glue_ctx._jvm.DynamicFrame.apply(dataframe._jdf, glue_ctx._ssql_ctx),
                             glue_ctx, name)
-
 
     def unbox(self, path, format, transformation_ctx="", info = "", stageThreshold = 0, totalThreshold = 0, **options):
         """
@@ -389,6 +385,10 @@ class DynamicFrame(object):
 
     def unnest_ddb_json(self, transformation_ctx="", info="", stageThreshold=0, totalThreshold=0):
         new_jdf = self._jdf.unnestDDBJson(transformation_ctx, _call_site(self._sc, callsite(), info), long(stageThreshold), long(totalThreshold))
+        return DynamicFrame(new_jdf, self.glue_ctx, self.name)
+
+    def simplify_ddb_json(self):
+        new_jdf = self._jdf.simplifyDDBJson()
         return DynamicFrame(new_jdf, self.glue_ctx, self.name)
 
     def resolveChoice(self, specs=None, choice="", database=None, table_name=None,

--- a/awsglue/gluetypes.py
+++ b/awsglue/gluetypes.py
@@ -139,6 +139,9 @@ class StringType(AtomicType):
 class TimestampType(AtomicType):
     pass
 
+class TimestampNTZType(AtomicType):
+    pass
+
 
 class UnknownType(AtomicType):
     pass
@@ -340,19 +343,19 @@ class EntityType(DataType):
 
 _atomic_types = [BinaryType, BooleanType, ByteType, DateType, DecimalType,
                  DoubleType, EnumType, FloatType, IntegerType, LongType, NullType,
-                 ShortType, StringType, TimestampType, UnknownType]
+                 ShortType, StringType, TimestampType, TimestampNTZType, UnknownType]
 
 
 _complex_types = [ArrayType, ChoiceType, MapType, StructType, SetType]
 
 
-_atomic_type_map = dict((t.typeName(), t) for t in _atomic_types)
+_atomic_type_map = dict((t.typeName(), t) for t in _atomic_types) # type: ignore
 
 
 _complex_type_map = dict((t.typeName(), t) for t in _complex_types)
 
 
-_all_type_map = dict((t.typeName(), t) for t in _atomic_types + _complex_types)
+_all_type_map = dict((t.typeName(), t) for t in _atomic_types + _complex_types) # type: ignore
 
 
 def _deserialize_json_string(json_str):

--- a/awsglue/job.py
+++ b/awsglue/job.py
@@ -9,7 +9,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
 # or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
+from py4j.java_gateway import java_import # type: ignore
 class Job:
     @classmethod
     def continuation_options(cls):
@@ -33,13 +33,23 @@ class Job:
     @classmethod
     def data_lineage_options(cls):
         return [ '--enable-data-lineage']
-    
-    def __init__(self, glue_context):
-        self._job = glue_context._jvm.Job
-        self._glue_context = glue_context
+    def __init__(self, glue_context_or_spark_session):
+        from pyspark.sql import SparkSession
+        from awsglue.context import GlueContext
+        if isinstance(glue_context_or_spark_session, GlueContext):
+            self._job = glue_context_or_spark_session._jvm.Job
+            self._glue_context = glue_context_or_spark_session
+            self._spark_session = glue_context_or_spark_session.sparkSession
+        elif isinstance(glue_context_or_spark_session, SparkSession):
+            java_import(glue_context_or_spark_session._jvm, "com.amazonaws.services.glue.util.Job")
+            self._job = glue_context_or_spark_session._jvm.Job
+            self._glue_context = None
+            self._spark_session = glue_context_or_spark_session
+        else:
+            raise Exception("cannot init Job instance given input parameter type: " + str(type(glue_context_or_spark_session)))
 
     def init(self, job_name, args = {}):
-        self._job.init(job_name, self._glue_context._glue_scala_context, args)
+        self._job.init(job_name, self._spark_session._jsparkSession, args)
 
     def isInitialized(self):
         return self._job.isInitialized()

--- a/awsglue/scripts/activate_etl_connector.py
+++ b/awsglue/scripts/activate_etl_connector.py
@@ -26,7 +26,7 @@ import shutil
 import string
 import subprocess
 import sys
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 from os import path
 
@@ -43,6 +43,7 @@ CUSTOM = "CUSTOM"
 HTTP_PROXY = "HTTP_PROXY"
 HTTPS_PROXY = "HTTPS_PROXY"
 NO_PROXY = "NO_PROXY"
+ECR_HOST_PATTERN = r"^([0-9]{12})\.dkr\.ecr\.[a-z]{2}-[a-z]{4}-[0-9]\.amazonaws\.com$"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -95,6 +96,7 @@ def extract_ecr_region(ecr_root: str) -> Union[None, str]:
     for region in session.get_available_regions("ecr"):
         if region in ecr_root:
             return region
+    return None
 
 
 def extract_registry_id(ecr_root: str) -> str:
@@ -102,7 +104,7 @@ def extract_registry_id(ecr_root: str) -> str:
     Extract AWS account id of the ECR registry from its root address
     e.g. xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com
     """
-    match = re.match(r"^(\d{12})\.dkr\.ecr\.[a-z]{2}-[a-z]{4}-\d\.amazonaws\.com$", ecr_root)
+    match = re.match(ECR_HOST_PATTERN, ecr_root)
     if match:
         return match.group(1)
     else:
@@ -129,7 +131,7 @@ def parse_ecr_url(ecr_url: str) -> Tuple[str, str, str]:
     E.g. https://xxxxxxxxxxxx.dkr.ecr.us-east-1.amazonaws.com/salesforce:7.2.0-latest
     """
     ecr_root, repo = parse_url(ecr_url)
-    if not re.match("^\d{12}\.dkr\.ecr\.[a-z]{2}-[a-z]{4}-\d\.amazonaws\.com$", ecr_root):
+    if not re.match(ECR_HOST_PATTERN, ecr_root):
         raise ValueError("malformed registry, correct pattern is https://aws_account_id.dkr.ecr.region.amazonaws.com")
     if not re.match("^[^:]+:[^:]+$", repo):
         raise ValueError("malformed image name, only one colon allowed to delimit image name and tag")
@@ -208,13 +210,13 @@ def id_generator(size: int = 5, chars: str = string.ascii_uppercase + string.dig
     return ''.join(random.choice(chars) for _ in range(size))
 
 
-def get_connection(region: str, endpoint: str, conn: str, proxy: str = None) -> Union[Dict, None]:
+def get_connection(region: str, endpoint: str, conn: str, proxy: Optional[str] = None) -> Union[Dict, None]:
     """
     Get catalog connection metadata by calling Boto3 get_connection API, supports custom supplied region and endpoint.
     """
     config = Config()
     if proxy:
-        config.proxies = {'https': proxy}
+        config.proxies = {'https': proxy} # type: ignore
     glue = boto3.Session().client(
         service_name="glue",
         region_name=region,
@@ -267,7 +269,7 @@ def download_custom_jars(conn: Dict[str, Any], dest_folder: str = "/tmp/custom_c
     return res
 
 
-def download_jars_per_connection(conn: str, region: str, endpoint: str, proxy: str = None) -> List[str]:
+def download_jars_per_connection(conn: str, region: str, endpoint: str, proxy: Optional[str] = None) -> List[str]:
     # validate connection type
     connection = get_connection(region, endpoint, conn, proxy)
     if connection is None:

--- a/awsglue/scripts/crawler_redo_from_backup.py
+++ b/awsglue/scripts/crawler_redo_from_backup.py
@@ -20,7 +20,6 @@ from awsglue.dynamicframe import DynamicFrame
 from awsglue.transforms import get_transform
 from pyspark.sql.types import *
 from .scripts_utils import *
-from pyspark.sql.functions import *
 
 def crawler_redo_from_backup(glue_context, **options):
     spark_ctxt = glue_context._instantiatedContext

--- a/awsglue/scripts/crawler_undo.py
+++ b/awsglue/scripts/crawler_undo.py
@@ -21,7 +21,7 @@ from awsglue.dynamicframe import DynamicFrame
 from awsglue.transforms import get_transform
 from pyspark.sql.types import *
 from .scripts_utils import *
-from pyspark.sql.functions import *
+from pyspark.sql.functions import col
 
 def crawler_backup(glue_context, data, options):
     crawler_name = options['crawler.name']


### PR DESCRIPTION
## Summary
- `GlueContext` now accepts optional `sparkContext` param and supports receiving a `SparkSession` directly
- `Job.__init__` accepts either `GlueContext` or `SparkSession`
- Remove unused `StreamingQueryException` import
- Minor cleanups across dataframe_transforms, scripts, and gluetypes